### PR TITLE
pluralisation fixes

### DIFF
--- a/eagle-lbr2kicad-1.0.ulp
+++ b/eagle-lbr2kicad-1.0.ulp
@@ -87,7 +87,7 @@
  * 26.07.2014: Fix Squ Pad size 0 problem in module
  *             Thanks to: Lachlan  "lachlanusa (at) gmail.com"
  *
- * 14.07.2014: Add option allows combining of device's into one KiCad lib part if the pin name/number match exactly.
+ * 14.07.2014: Add option allows combining of devices into one KiCad lib part if the pin name/number match exactly.
  *             Note: Pin number/name IS the deciding factor! NOT package type or package pin count.
  *             Thanks to: Lachlan  "lachlanusa (at) gmail.com"
  *
@@ -242,7 +242,7 @@ string logfileName;
 string logfile;
 string outputPath;
 
-string infoDeviceConversion = "<pre>Allows combining of device's into one KiCad lib part if the pin name/number match exactly.<br>"+
+string infoDeviceConversion = "<pre>Allows combining of devices into one KiCad lib part if the pin name/number match exactly.<br>"+
                               "Note pin number/name not package type or the number of pins on the package is the deciding factor.<br>"+
                               "If not enabled conversion will make a new KiCad library part/module for every one of eagle<br>devices/footprint this of course "+
                               "makes for a very large KiCad library so this give's<br>the option of combining the eagle part's where"+
@@ -2363,7 +2363,7 @@ void write_kikad_lib( string fileName )
                         currentDeviceCt++;
                     } // D.devices(DEV)
 
-                    // clear device's info
+                    // clear devices info
                     ct1 = DevSetPackageCount;
                     for( ct = 0 ; ct1; ct1--)  // clear list
                     {

--- a/eagle-lbr2kicad-1.0.ulp
+++ b/eagle-lbr2kicad-1.0.ulp
@@ -81,7 +81,7 @@
  * 26.07.2014: Fix >NAME and >VALUE in in module, so eagle text is not lost, or confused with module prefix/value
  *             Thanks to: Lachlan  "lachlanusa (at) gmail.com"
  *
- * 26.07.2014: Fix text width in module, so module text use's eagles text width.
+ * 26.07.2014: Fix text width in module, so module text uses eagles text width.
  *             Thanks to: Lachlan  "lachlanusa (at) gmail.com"
  *
  * 26.07.2014: Fix Squ Pad size 0 problem in module
@@ -262,7 +262,7 @@ string infoPostFixSeach = "Add a wild card post-fix '*' to each footprint in the
 
 string infoNoPrefix = "If a eagle lib part has no prefix IE:  \"U\", \"R\", \"C\" etc, then we use this letter(s) for SCH/Part Prefix";
 
-string infoFootPrintList = "KiCad use's the footprint list to help select from the list of PCB module/footprint(s) in KiCad's module lib.<br>This option controls the output, and output format"+
+string infoFootPrintList = "KiCad uses the footprint list to help select from the list of PCB module/footprint(s) in KiCad's module lib.<br>This option controls the output, and output format"+
                            " given to KiCad<br>Note: This is not the same as KiCad footprint";
 
 string infoFootPrint = "<pre>You have 2 options, for the footprint name in KiCad.<br>Just use eagle device name for the footprint name in KiCad,<br>"+
@@ -274,7 +274,7 @@ string infoFootPrint = "<pre>You have 2 options, for the footprint name in KiCad
 
 string infoFootPrintPrefix = "You can override the default eagle lib name, which is the prefix to the KiCad footprint name.<br>Note: that this program always adds '_' between  prefix name and foot print name.";
 
-string infoTextMaxMinValue = "<pre>You can override text font line width size in eagle, and use the Max and Min line width,<br>which KiCad use's to draw the text<br>"+
+string infoTextMaxMinValue = "<pre>You can override text font line width size in eagle, and use the Max and Min line width,<br>which KiCad uses to draw the text<br>"+
                              "IE:  Any text line width which is bigger than Max line will be replaced with Max value.<br>"+
                              "     Any text line width which is less than Min line will be replaced with Min width value.</pre>";
 

--- a/eagle-lbr2kicad-1.0.ulp
+++ b/eagle-lbr2kicad-1.0.ulp
@@ -74,7 +74,7 @@
  *             Thanks to: Lachlan  "lachlanusa (at) gmail.com"
  *
  * 05.09.2014: Try a number of fixes for part name, and ALISA list,  to work better with eagle2kicad_sch.ulp
- *             Note there are many problems here. See as badly name eagle lib's will make for lot's of devices name collisions!
+ *             Note there are many problems here. See as badly name eagle libs will make for lot's of devices name collisions!
  *             Which will make KiCad stop loading the lib/mod!
  *             Thanks to: Lachlan  "lachlanusa (at) gmail.com"
  *
@@ -280,7 +280,7 @@ string infoTextMaxMinValue = "<pre>You can override text font line width size in
 
 string infoProgramHowTo = "This program converts a eagle lib to KiCad lib and mod lib.<br>You have a number of options to how this conversion is done.<br>"+
                           "<b><br><i>WARNING: You should check the results of the conversion!<br>As there is no way this program will make a perfect conversion<i></b>"+
-                          "<pre><b><font color=red>BUGS and and warnings:<br>  1: Text can appear on any layer in Eagle lib's, where as KiCad only allows Text on top layer<br>"+
+                          "<pre><b><font color=red>BUGS and and warnings:<br>  1: Text can appear on any layer in Eagle libs, where as KiCad only allows Text on top layer<br>"+
                           "     This will result in all text from eagle appearing on the top silk screen layer,<br>     and mirrored text will no longer be mirrored !</pre></font>"+
                           "<i>This version of eagle-to-kicad is hosted on <a href=\"http://github.com/lachlanA/eagle-to-kicad/\">https://github.com/lachlanA/eagle-to-kicad</a><br>"+
                           "Please check this site for latest version, bug reports, and to make suggestions/improvement<br><i>";

--- a/eagle-lbr2kicad-1.0.ulp
+++ b/eagle-lbr2kicad-1.0.ulp
@@ -73,7 +73,7 @@
  * 05.09.2014: Inc version number to 1.1
  *             Thanks to: Lachlan  "lachlanusa (at) gmail.com"
  *
- * 05.09.2014: Try a number of fix's for part name, and ALISA list,  to work better with eagle2kicad_sch.ulp
+ * 05.09.2014: Try a number of fixes for part name, and ALISA list,  to work better with eagle2kicad_sch.ulp
  *             Note there are many problems here. See as badly name eagle lib's will make for lot's of devices name collisions!
  *             Which will make KiCad stop loading the lib/mod!
  *             Thanks to: Lachlan  "lachlanusa (at) gmail.com"

--- a/eagle-lbr2kicad-1.0.ulp
+++ b/eagle-lbr2kicad-1.0.ulp
@@ -205,10 +205,10 @@ int devicesCount = 0;
 int deleteTextArfterATsysbolInPinName = 1;   //Eagle dos not show any text in pin name's arfter the @ sysbold.
 int deleteNameTextSCH = 1;   //Delete >Name from schematic
 int deleteValueTextSCH = 1;   //Delete >Value from schematic
-string  symbolicPrefix;      /*list  symbolic prefix(s)(commer seperated) not to show pin's or pad's or Part, or symbolic prefix for,  Note list format is D, C, X, V, #  */
+string  symbolicPrefix;      /*list  symbolic prefix(s)(commer seperated) not to show pin's or pads or Part, or symbolic prefix for,  Note list format is D, C, X, V, #  */
 
 int dontShowPin = 1;   //Dont show pin's from symbloicPrefix list
-int dontShowPad = 1;   //Dont show Pad's from symbloicPrefix list
+int dontShowPad = 1;   //Dont show pads from symbloicPrefix list
 int dontShowPartName = 1;   //Dont show part name from symbloicPrefix list
 int dontShowPartValue = 1;   //Dont show part name from symbloicPrefix list
 

--- a/eagle-lbr2kicad-1.0.ulp
+++ b/eagle-lbr2kicad-1.0.ulp
@@ -245,7 +245,7 @@ string outputPath;
 string infoDeviceConversion = "<pre>Allows combining of device's into one KiCad lib part if the pin name/number match exactly.<br>"+
                               "Note pin number/name not package type or the number of pins on the package is the deciding factor.<br>"+
                               "If not enabled conversion will make a new KiCad library part/module for every one of eagle<br>devices/footprint this of course "+
-                              "make's for a very large KiCad library so this give's<br>the option of combining the eagle part's where"+
+                              "makes for a very large KiCad library so this give's<br>the option of combining the eagle part's where"+
                               " possible to make a Kicad library,<br>there is some risk to this, as the matching process could have<br>"+
                               "<b><br>So it's import you check the results when using this option<b>!!!</b></pre>";
 

--- a/eagle-lbr2kicad-1.0.ulp
+++ b/eagle-lbr2kicad-1.0.ulp
@@ -50,7 +50,7 @@
  * 27.08.2015:  Fix Power systembal to correct for KiCad Power fills, change power supllie to opersit of Eagle.
  *              Change pin to hide when power. supply system.
  *
- * 19.07.2015:  Fix / slash in Ealge's lib and part name's and device name
+ * 19.07.2015:  Fix / slash in Ealge's lib and part names and device name
  *              Add faster string replace/subsute sub "string charstr_replace(string search, string replace, string subject)"
  *              Thanks to: Lachlan  "lachlanusa (at) gmail.com"
  *
@@ -202,7 +202,7 @@ int eaglePartToKiCadPartConversion = 0; // control's if we cobine footprints or 
 int devicesetsCount = 0;
 int devicesCount = 0;
 
-int deleteTextArfterATsysbolInPinName = 1;   //Eagle dos not show any text in pin name's arfter the @ sysbold.
+int deleteTextArfterATsysbolInPinName = 1;   //Eagle dos not show any text in pin names arfter the @ sysbold.
 int deleteNameTextSCH = 1;   //Delete >Name from schematic
 int deleteValueTextSCH = 1;   //Delete >Value from schematic
 string  symbolicPrefix;      /*list  symbolic prefix(s)(commer seperated) not to show pin's or pads or Part, or symbolic prefix for,  Note list format is D, C, X, V, #  */
@@ -1861,7 +1861,7 @@ void write_kikad_lib( string fileName )
                     devicesCount = 0;
 
                     //********************************
-                    // Find the number of deivce's and add the name's to a aray list of device names/package name lists,
+                    // Find the number of deivce's and add the names to a aray list of device names/package name lists,
                     // Also pin list for compair
                     int DevSetPackageCount = 0;
                     D.devices(DEV)
@@ -2755,7 +2755,7 @@ int main()
     if( ( strlen(tmpXX) >= 1 ))   // Has it been set ?
         if ( strtol( tmpXX ) == 1 ) // Yes
         {
-            add_libnamePrefixToPartName = 0; // Dont add lib name's to deivce name's for now *** !!
+            add_libnamePrefixToPartName = 0; // Dont add lib names to deivce names for now *** !!
             outPutFootPrint = 0; // Don't add lib name to foot print name as it has aready been added for now ****!!
         }
         else

--- a/eagle6xx-sch-to-kicad-sch.ulp
+++ b/eagle6xx-sch-to-kicad-sch.ulp
@@ -38,14 +38,14 @@
  * 16.10.2015: Ajust offset for sch postion, to fit sheet a bit better.
  *             Thanks to: Lachlan  "lachlanusa (at) gmail.com" 
  *
- * 16.10.2015: Add check for name conflict on lib's package and symbol's,
+ * 16.10.2015: Add check for name conflict on libs package and symbol's,
  *             and enable add libname prefix if there is.
  *             Thanks to: Lachlan  "lachlanusa (at) gmail.com" 
  *
  * 13.10.2015: Fix Quoteing of lib name in ft_tables
  *             Thanks to: Lachlan  "lachlanusa (at) gmail.com" 
  *
- * 31.07.2015: Add warning about Eagle lib's Ghost parts
+ * 31.07.2015: Add warning about Eagle libs Ghost parts
  *             Add check/warning for wrong path to converstion scripts.
  *             Fix some spelling stuff.
  *             Thanks to: Lachlan  "lachlanusa (at) gmail.com" 
@@ -131,7 +131,7 @@ string infoHelp             = "This ULP is a converts from Eagle SCH/PCB to KiCa
                               " ";
 string infoULPdir           = "<b>Eagle ULP conversion script location</b>";
 
-string infoPartNameConflict = "Eagle allows duplicate part names in SCH/PCB if they come from different lib's<br>"+
+string infoPartNameConflict = "Eagle allows duplicate part names in SCH/PCB if they come from different libs<br>"+
                               "<b>IE:</b><br><i><b> libfred<b></i>:74LS00:,<br>"+
                               "<i><b> libnerd<b></i>:74LS00,<br><br>"+
                               "While KiCad dose not allow duplication's in part names<br>"+
@@ -139,11 +139,11 @@ string infoPartNameConflict = "Eagle allows duplicate part names in SCH/PCB if t
                               "You have 2 options:<br><br> 1: Rename the part in ealge's LIB/SCH/PCB. <i>If you have access to them</i><br> 2: Tick this option <b><i>Adding lib name to Part Name</b></i><br><br>"+
                               "Which allowing this program to add lib prefix to the part name. This also fixes the problem.<br>"+
                               "<br><b><font color=\"purple\">Note 1: This program automatically check's for conflicts and set's the option if needed<br><br></b>"+
-                              "<b><font color=\"red\">Note 2: Eagle has some nasty bugs in there library management,  which is some case's there will be ghost parts in the lib's!<br>"+
+                              "<b><font color=\"red\">Note 2: Eagle has some nasty bugs in there library management,  which is some case's there will be ghost parts in the libs!<br>"+
                               "<b>IE: parts which you don't use in your SCH but are still output from the lib-export stage of this program,  which will magically be used instead of the part you have designed with !<br>"+
                               "The only way to get this problem, is to turn the <i>Adding lib name to Part Name: back on!" ;
 
-string infoCombineLibNames  = "Combine all the separate Eagle lib's into one KiCad lib<br>"+
+string infoCombineLibNames  = "Combine all the separate Eagle libs into one KiCad lib<br>"+
                               "This make's the conversion process easy and faster.<br>"+
                               "<b>But means that you may lose tack of which parts<br>"+
                               "come from which Eagle lib</b><br>";
@@ -168,7 +168,7 @@ string infoNetLableFix      = "<u><b><font color=\"red\">The problem:</font></b>
                               " While this solution is a real hack it's on the only way to get get around the net label placement problems"+
                               " KiCad has";
 
-string infoExportLibsFromEagle = "Extract lib's from Eagle SCH/PCB for KiCad <i>lib module.</i><br>"+
+string infoExportLibsFromEagle = "Extract libs from Eagle SCH/PCB for KiCad <i>lib module.</i><br>"+
                                  "<b><i>NOTE:</b></i> If you <b><i><u>don't</b></i></u> use this option, you will need to find<br>"+
                                  "the Eagle <i>.lbr(s)</i> library's files and convert those across<br>"+
                                  " one by one using the Eagle-lbr2kicad-1.0.ulp";
@@ -783,7 +783,7 @@ int getCurrentTimeHack()
 }
 
 //
-// Make list of all the lib's used.
+// Make list of all the libs used.
 //
 int makeLibeList( UL_SCHEMATIC SCH )
 {
@@ -798,7 +798,7 @@ int makeLibeList( UL_SCHEMATIC SCH )
 }
 
 //***************
-// Make list of all the device lib's refaces used.
+// Make list of all the device libs refaces used.
 // And seach for conflicts
 // returns 0 if ok,
 // or confict count
@@ -2233,7 +2233,7 @@ void write_kicad_components( UL_SHEET S )
 	      // if >NAME and >VALUE are not smashed, they wont apear here.
 	      // But in  I.gate.symbol.texts(T) section, Also note that depending on weather the 
 	      // >NAME and/or >VALUE have been changed/deleted then added back in the Eagle lib,  and the sch is update from
-	      // that Eagle lib's, the >NAME and/or >VALUE could be in any order in I.gate.symbol.texts(T)
+	      // that Eagle libs, the >NAME and/or >VALUE could be in any order in I.gate.symbol.texts(T)
 	      // section's !! how brain dead is that.. !!
 	      I.texts(T)
 		{
@@ -2554,7 +2554,7 @@ void write_kicad_components( UL_SHEET S )
 	      // if >NAME and >VALUE are not smashed, they wont apear here.
 	      // But in  I.gate.symbol.texts(T) section, Also note that depending on weather the 
 	      // >NAME and/or >VALUE have been changed/deleted then added back in the Eagle lib,  and the sch is update from
-	      // that Eagle lib's, the >NAME and/or >VALUE could be in any order in I.gate.symbol.texts(T)
+	      // that Eagle libs, the >NAME and/or >VALUE could be in any order in I.gate.symbol.texts(T)
 	      // section's !! how brain dead is that.. !!
               count = 0;
               string prefixToValue = "";

--- a/eagle6xx-sch-to-kicad-sch.ulp
+++ b/eagle6xx-sch-to-kicad-sch.ulp
@@ -144,7 +144,7 @@ string infoPartNameConflict = "Eagle allows duplicate part names in SCH/PCB if t
                               "The only way to get this problem, is to turn the <i>Adding lib name to Part Name: back on!" ;
 
 string infoCombineLibNames  = "Combine all the separate Eagle libs into one KiCad lib<br>"+
-                              "This make's the conversion process easy and faster.<br>"+
+                              "This makes the conversion process easy and faster.<br>"+
                               "<b>But means that you may lose tack of which parts<br>"+
                               "come from which Eagle lib</b><br>";
 
@@ -3632,7 +3632,7 @@ int main()
     output(logfileName, "at") printf("%s", logfile);
 
     // check to see if we have a pcb ready,
-    // if we dont make up,  for the save as from pcbnew, just make's things bit simpler
+    // if we dont make up,  for the save as from pcbnew, just makes things bit simpler
     // 
     string pcbfilename;
     pcbfilename = filesetext( outputPath + rootschname, ".kicad_pcb");

--- a/eagle6xx-sch-to-kicad-sch.ulp
+++ b/eagle6xx-sch-to-kicad-sch.ulp
@@ -2234,7 +2234,7 @@ void write_kicad_components( UL_SHEET S )
 	      // But in  I.gate.symbol.texts(T) section, Also note that depending on weather the 
 	      // >NAME and/or >VALUE have been changed/deleted then added back in the Eagle lib,  and the sch is update from
 	      // that Eagle libs, the >NAME and/or >VALUE could be in any order in I.gate.symbol.texts(T)
-	      // section's !! how brain dead is that.. !!
+	      // sections !! how brain dead is that.. !!
 	      I.texts(T)
 		{
 		  strItext[ ItextCount ] = T.value;
@@ -2555,7 +2555,7 @@ void write_kicad_components( UL_SHEET S )
 	      // But in  I.gate.symbol.texts(T) section, Also note that depending on weather the 
 	      // >NAME and/or >VALUE have been changed/deleted then added back in the Eagle lib,  and the sch is update from
 	      // that Eagle libs, the >NAME and/or >VALUE could be in any order in I.gate.symbol.texts(T)
-	      // section's !! how brain dead is that.. !!
+	      // sections !! how brain dead is that.. !!
               count = 0;
               string prefixToValue = "";
 

--- a/eagle6xx-sch-to-kicad-sch.ulp
+++ b/eagle6xx-sch-to-kicad-sch.ulp
@@ -127,7 +127,7 @@ string infoTargetDirectory  = "<h3>Set the target directory for all the converte
                              "With out any other file's, as the contents may be<center><font color=\"red\">OVER WRITTEN WITHOUT WARNING!</b></center>";
 
 string infoHelp             = "This ULP is a converts from Eagle SCH/PCB to KiCad sch/PCB<br>"+
-                              "It consist of 3 different ULP's hack to work together<br>"+
+                              "It consist of 3 different ULPs hack to work together<br>"+
                               " ";
 string infoULPdir           = "<b>Eagle ULP conversion script location</b>";
 
@@ -3134,7 +3134,7 @@ int mainDialog( string titleString, int sheetcount, string schName )
                 dlgCheckBox("Save as default", saveAsDefaultULP_Path );
                 dlgPushButton("Edit") {
                   string xs;int it;
-                  xs = dlgDirectory("Select directory containing conversion ULP's", "C:\\");
+                  xs = dlgDirectory("Select directory containing conversion ULPs", "C:\\");
                   if( strlen(xs) )
                     tmpS10 = myULP_HOME = ( xs + '/');
                 }

--- a/eagle6xx-sch-to-kicad-sch.ulp
+++ b/eagle6xx-sch-to-kicad-sch.ulp
@@ -131,10 +131,10 @@ string infoHelp             = "This ULP is a converts from Eagle SCH/PCB to KiCa
                               " ";
 string infoULPdir           = "<b>Eagle ULP conversion script location</b>";
 
-string infoPartNameConflict = "Eagle allows duplicate part name's in SCH/PCB if they come from different lib's<br>"+
+string infoPartNameConflict = "Eagle allows duplicate part names in SCH/PCB if they come from different lib's<br>"+
                               "<b>IE:</b><br><i><b> libfred<b></i>:74LS00:,<br>"+
                               "<i><b> libnerd<b></i>:74LS00,<br><br>"+
-                              "While KiCad dose not allow duplication's in part name's<br>"+
+                              "While KiCad dose not allow duplication's in part names<br>"+
                               "In most case's there is no conflict, but if there is a conflict.<br>"+
                               "You have 2 options:<br><br> 1: Rename the part in ealge's LIB/SCH/PCB. <i>If you have access to them</i><br> 2: Tick this option <b><i>Adding lib name to Part Name</b></i><br><br>"+
                               "Which allowing this program to add lib prefix to the part name. This also fix's the problem.<br>"+

--- a/eagle6xx-sch-to-kicad-sch.ulp
+++ b/eagle6xx-sch-to-kicad-sch.ulp
@@ -137,7 +137,7 @@ string infoPartNameConflict = "Eagle allows duplicate part names in SCH/PCB if t
                               "While KiCad dose not allow duplication's in part names<br>"+
                               "In most case's there is no conflict, but if there is a conflict.<br>"+
                               "You have 2 options:<br><br> 1: Rename the part in ealge's LIB/SCH/PCB. <i>If you have access to them</i><br> 2: Tick this option <b><i>Adding lib name to Part Name</b></i><br><br>"+
-                              "Which allowing this program to add lib prefix to the part name. This also fix's the problem.<br>"+
+                              "Which allowing this program to add lib prefix to the part name. This also fixes the problem.<br>"+
                               "<br><b><font color=\"purple\">Note 1: This program automatically check's for conflicts and set's the option if needed<br><br></b>"+
                               "<b><font color=\"red\">Note 2: Eagle has some nasty bugs in there library management,  which is some case's there will be ghost parts in the lib's!<br>"+
                               "<b>IE: parts which you don't use in your SCH but are still output from the lib-export stage of this program,  which will magically be used instead of the part you have designed with !<br>"+
@@ -163,7 +163,7 @@ string infoNetLableFix      = "<u><b><font color=\"red\">The problem:</font></b>
                               " GLOBAL, <i>(works on all sheets)</i><br>"+
                               " The Eagle script first check to see if the net label is only on the current sheet, or on"+
                               " multiple sheets and then assigns a local or global KiCad net label at the wire/part juction<br>"+
-                              " This fix's any problems with placement of net label name in Eagle.<br>"+
+                              " This fixes any problems with placement of net label name in Eagle.<br>"+
                               " And for KiCad, we have a option to set the net label name size, so it's not too much of a eyesore.<br>"+
                               " While this solution is a real hack it's on the only way to get get around the net label placement problems"+
                               " KiCad has";

--- a/eagle6xx-sch-to-kicad-sch.ulp
+++ b/eagle6xx-sch-to-kicad-sch.ulp
@@ -38,7 +38,7 @@
  * 16.10.2015: Ajust offset for sch postion, to fit sheet a bit better.
  *             Thanks to: Lachlan  "lachlanusa (at) gmail.com" 
  *
- * 16.10.2015: Add check for name conflict on libs package and symbol's,
+ * 16.10.2015: Add check for name conflict on libs package and symbols,
  *             and enable add libname prefix if there is.
  *             Thanks to: Lachlan  "lachlanusa (at) gmail.com" 
  *

--- a/eagle6xx-sch-to-kicad-sch.ulp
+++ b/eagle6xx-sch-to-kicad-sch.ulp
@@ -139,7 +139,7 @@ string infoPartNameConflict = "Eagle allows duplicate part name's in SCH/PCB if 
                               "You have 2 options:<br><br> 1: Rename the part in ealge's LIB/SCH/PCB. <i>If you have access to them</i><br> 2: Tick this option <b><i>Adding lib name to Part Name</b></i><br><br>"+
                               "Which allowing this program to add lib prefix to the part name. This also fix's the problem.<br>"+
                               "<br><b><font color=\"purple\">Note 1: This program automatically check's for conflicts and set's the option if needed<br><br></b>"+
-                              "<b><font color=\"red\">Note 2: Eagle has some nasty bug's in there library management,  which is some case's there will be ghost parts in the lib's!<br>"+
+                              "<b><font color=\"red\">Note 2: Eagle has some nasty bugs in there library management,  which is some case's there will be ghost parts in the lib's!<br>"+
                               "<b>IE: parts which you don't use in your SCH but are still output from the lib-export stage of this program,  which will magically be used instead of the part you have designed with !<br>"+
                               "The only way to get this problem, is to turn the <i>Adding lib name to Part Name: back on!" ;
 

--- a/eagle6xx-sch-to-kicad-sch.ulp
+++ b/eagle6xx-sch-to-kicad-sch.ulp
@@ -135,11 +135,11 @@ string infoPartNameConflict = "Eagle allows duplicate part names in SCH/PCB if t
                               "<b>IE:</b><br><i><b> libfred<b></i>:74LS00:,<br>"+
                               "<i><b> libnerd<b></i>:74LS00,<br><br>"+
                               "While KiCad dose not allow duplication's in part names<br>"+
-                              "In most case's there is no conflict, but if there is a conflict.<br>"+
+                              "In most cases there is no conflict, but if there is a conflict.<br>"+
                               "You have 2 options:<br><br> 1: Rename the part in ealge's LIB/SCH/PCB. <i>If you have access to them</i><br> 2: Tick this option <b><i>Adding lib name to Part Name</b></i><br><br>"+
                               "Which allowing this program to add lib prefix to the part name. This also fixes the problem.<br>"+
                               "<br><b><font color=\"purple\">Note 1: This program automatically check's for conflicts and set's the option if needed<br><br></b>"+
-                              "<b><font color=\"red\">Note 2: Eagle has some nasty bugs in there library management,  which is some case's there will be ghost parts in the libs!<br>"+
+                              "<b><font color=\"red\">Note 2: Eagle has some nasty bugs in there library management,  which is some cases there will be ghost parts in the libs!<br>"+
                               "<b>IE: parts which you don't use in your SCH but are still output from the lib-export stage of this program,  which will magically be used instead of the part you have designed with !<br>"+
                               "The only way to get this problem, is to turn the <i>Adding lib name to Part Name: back on!" ;
 

--- a/eagle6xx-sch-to-kicad-sch.ulp
+++ b/eagle6xx-sch-to-kicad-sch.ulp
@@ -2750,7 +2750,7 @@ void write_kicad_netNames( UL_SHEET SH, int current_sheet )
     else     // check to see if there was a polygon with the same net name
       if( array_find_poly_messagex( N.name, polygons_linesCt ))
         globalable = 1; 
-        //****** Force globalable for quick fix to fill's net name problem. *******//
+        //****** Force globalable for quick fix to fills net name problem. *******//
 
     
     //    N.pinrefs(R)

--- a/exp-lbrs.ulp
+++ b/exp-lbrs.ulp
@@ -1207,7 +1207,7 @@ int Result = dlgDialog(TR("Export EAGLE libraries from drawing")) {
 
         if( ( ConflictPartsCount > 0 ) && ( AddLibPrefix != 1 ))
         {
-          if( dlgMessageBox("!Warning there are Part's with have the same name's,  but from diffent libs" +
+          if( dlgMessageBox("!Warning there are Part's with have the same names,  but from diffent libs" +
                             " KICAD will reject part which have name!" +
                             " Please tick the Add library names as prefix to get around this problem" +
                             " Or fix the part name in the lib refance"+

--- a/exp-lbrs.ulp
+++ b/exp-lbrs.ulp
@@ -1221,7 +1221,7 @@ int Result = dlgDialog(TR("Export EAGLE libraries from drawing")) {
         if( Merge > 0)
           make_one_lbr(); // one lib for all deives
         else
-          make_lbr();  //  septrate lib's for all device's
+          make_lbr();  //  septrate libs for all device's
         show_save_script_file(cmd);
 
 

--- a/exp-lbrs.ulp
+++ b/exp-lbrs.ulp
@@ -1042,7 +1042,7 @@ void make_lbr(void) {
 
 
 //---------------------------------------
-// make one lib for all deives
+// make one lib for all devices
 //---------------------------------------
 void make_one_lbr(void) {
 
@@ -1219,9 +1219,9 @@ int Result = dlgDialog(TR("Export EAGLE libraries from drawing")) {
 
         
         if( Merge > 0)
-          make_one_lbr(); // one lib for all deives
+          make_one_lbr(); // one lib for all devices
         else
-          make_lbr();  //  septrate libs for all device's
+          make_lbr();  //  septrate libs for all devices
         show_save_script_file(cmd);
 
 

--- a/exp-lbrs.ulp
+++ b/exp-lbrs.ulp
@@ -15,7 +15,7 @@
 //-------------------------------------------------------------------------------- 
 // Change log.
 // Date:    Note:
-// 09-Oct-2015  Fix layer's for limted version of Eagle L. A.
+// 09-Oct-2015  Fix layers for limted version of Eagle L. A.
 // 25-Aug-2015  Fix space in Path problem, for windows by adding ' ' L. A.
 // 31-Jul-2015  Fix some spelling mistakes.  L. A.
 // 28-Jul-2015  Fix a number of problems where,  Pin and pads over lap, and add error reporting log file.

--- a/exp-lbrs.ulp
+++ b/exp-lbrs.ulp
@@ -18,7 +18,7 @@
 // 09-Oct-2015  Fix layer's for limted version of Eagle L. A.
 // 25-Aug-2015  Fix space in Path problem, for windows by adding ' ' L. A.
 // 31-Jul-2015  Fix some spelling mistakes.  L. A.
-// 28-Jul-2015  Fix a number of problems where,  Pin and Pad's over lap, and add error reporting log file.
+// 28-Jul-2015  Fix a number of problems where,  Pin and pads over lap, and add error reporting log file.
 // 13-Mar-2015  Add more help to info boxs.  L. A.
 // 10-Feb-2015  Change hooks to work the other conversion programs.  L. A.
 //  
@@ -28,7 +28,7 @@
 string Version = "6.6";
 
 int TEMP_HOLD_FOR_OVER_LAPPING_PIN = 19180;  //  Tempory of the sysmbole editor when we have over lapping pin's to deal with
-int TEMP_HOLD_FOR_OVER_LAPPING_SMD_PAD = 19180;  //  Tempory of the sysmbole editor when we have over lapping hole/smd pad's to deal with
+int TEMP_HOLD_FOR_OVER_LAPPING_SMD_PAD = 19180;  //  Tempory of the sysmbole editor when we have over lapping hole/smd pads to deal with
 
 
 

--- a/exp-lbrs.ulp
+++ b/exp-lbrs.ulp
@@ -33,7 +33,7 @@ int TEMP_HOLD_FOR_OVER_LAPPING_SMD_PAD = 19180;  //  Tempory of the sysmbole edi
 
 
 string infoCombineLibNames  = "Combine all the seprate Eagle libs into one KiCad lib<br>"+
-                              "This make's the conversion preccess easy and faster.<br>"+
+                              "This makes the conversion preccess easy and faster.<br>"+
                               "<b>But means that you lose tack of which parts<br>"+
                               "come from which Eagle lib</b><br>";
 

--- a/fix_via_hack.ulp
+++ b/fix_via_hack.ulp
@@ -848,7 +848,7 @@ void menue(void)
   result = dlgDialog("VIAs to Pad, and Track Check:" + "  BUILD DATE:" + BUILD_DATE )
       {
         dlgLabel("<b><font color=\"red\">This ULP will change unconnected VIAs to PADS<br>" + 
-                 "<font color=\"blue\">It will also Documents on user defined layer's unconnected VIAs and Tracks<br>" +
+                 "<font color=\"blue\">It will also Documents on user defined layers unconnected VIAs and Tracks<br>" +
                  "<i>Click on <i>Info</> for importand Note's!</i><br>"+
                  "<b>NOTE:<i> This hack modifies both the Eagle SCH and PCB file,<br>"+
                  "which are saved in the <i>TARGET-DIRECTORY</i>/modified_eagle_files/");

--- a/fix_via_hack.ulp
+++ b/fix_via_hack.ulp
@@ -276,7 +276,7 @@ string infoConvertViaToPad  =  "<b>Eagle use's VIAs for connections to fill's an
     "<b>they do on Eagle. But there  are some problems with this fix-<br><br>"+
     "1: Blind VIAs wont work, as Pads will go thou all layers,  while blind vie's only go thou the configured layers.<br>"+
     "2: The fix change's the Eagle SCH/PCB file's by converting VIAs to Pads, the hack change's the SCH by adding 1 Pin pads<br>"+
-    "&nbsp;&nbsp;&nbsp;&nbsp;this is a very big hack, you will see x=0 y=0-number diffident net's and pads in the Eagle SCH file<br>"+
+    "&nbsp;&nbsp;&nbsp;&nbsp;this is a very big hack, you will see x=0 y=0-number diffident nets and pads in the Eagle SCH file<br>"+
     "&nbsp;&nbsp;&nbsp;&nbsp;this mod-filed Eagle file's are saved in the $TARGETDIRECTOR/modified_eagle_files/";
 
 string infoDocFillOverPad  =  "<b>SMD Pads & Normal Pads can be covered with copper when Thermal connection is turned off<br>"+

--- a/fix_via_hack.ulp
+++ b/fix_via_hack.ulp
@@ -895,7 +895,7 @@ void menue(void)
           dlgCheckBox("Save as default", saveAsDefaultULP_Path );
           dlgPushButton("Edit") {
             string xs;int it;
-            xs = dlgDirectory("Select directory containing conversion ULP's", "C:\\");
+            xs = dlgDirectory("Select directory containing conversion ULPs", "C:\\");
             if( strlen(xs) )
               tmpS10 = myULP_HOME = ( xs + '/');
           }

--- a/fix_via_hack.ulp
+++ b/fix_via_hack.ulp
@@ -269,10 +269,10 @@ string infoTargetDirectory  =  "<b>Set the target directory for the KiCad/Eagle 
                              "<b>Note this directory should be a clean directory<br>"+
                              "With out any other file's, as the contents-<br><center><font color=\"red\"><font color=\"red\">WILL BE OVER WRITTEN WITHOUT WARNING!</b></center>";
 
-string infoConvertViaToPad  =  "<b>Eagle use's VIAs for connections to fills and power plane's, this works well for Eagle<br>"+
+string infoConvertViaToPad  =  "<b>Eagle use's VIAs for connections to fills and power planes, this works well for Eagle<br>"+
     "<b>But will not work for KiCad, because KiCad does not retain Net list information for unconnected VIAs and tracks<br>"+
     "<b>It only retains net information when the via is connected to a PAD, using a track<br>"+
-    "<b>By converting the unconnected VIAs to pads KiCad will keep the net information and allow fills and power plane's to work like<br>"+
+    "<b>By converting the unconnected VIAs to pads KiCad will keep the net information and allow fills and power planes to work like<br>"+
     "<b>they do on Eagle. But there  are some problems with this fix-<br><br>"+
     "1: Blind VIAs wont work, as Pads will go thou all layers,  while blind vie's only go thou the configured layers.<br>"+
     "2: The fix change's the Eagle SCH/PCB file's by converting VIAs to Pads, the hack change's the SCH by adding 1 Pin pads<br>"+
@@ -855,7 +855,7 @@ void menue(void)
 
         /* "This is needed because KiCad does not support Net Names on unconected VIAs/Tracks and blind Vias which have no Pad conecsion.!<br>"+ */
         /* "while unconected VIAs can be automatic coveted to pads blind VIAs and unconnected tracks need manual conversion</i>)<br>"+ */
-        /* "will lose net names, and will not connect to fills or power plane's!<br>"+ */
+        /* "will lose net names, and will not connect to fills or power planes!<br>"+ */
         /* "This hack will help out by converting all those unconnected VIAs to Pads<br>"+ */
         /* "<i>Click on Info for more, information and problem's which is could fix/make!</i><br>"+ */
         /* "<b>NOTE:<i> This hack modifies both the eagle sch and PCB file,  which are saved in the TARGET-DIRECTORY/modified_eagle_files/</i>"); */

--- a/fix_via_hack.ulp
+++ b/fix_via_hack.ulp
@@ -119,7 +119,7 @@ string ckname[];
 string cmd;  // holds the script to renumbing in sch
 string lib_cmd; // hold's script for building lib pads
 string pcb_cmd; // Hold scrtip for removeing VIAs and adding pads in it's place.
-string sch_cmd; // Hold script for sch pad's add.
+string sch_cmd; // Hold script for sch pads add.
 
 string c;
 
@@ -183,7 +183,7 @@ int docment_unnconeted_wires = 1;
 // Note this looks bit old, as we dont have a end X,Y
 // but old/end is the marker..  IE index 10 is start, index of 11 is end of same track.
 // layer start finish are,  always the same vale,
-// so that same rutine can check for connection's for pad's
+// so that same rutine can check for connection's for pads
 // VIAs,  wire's  
 int wire_X[];
 int wire_Y[];
@@ -196,8 +196,8 @@ int wire_index[];
 int wire_indexS[];
 int wire_indexF[];
 
-// Holds table of vire's pad's smd pad's
-// with pad's Sl and Fl 
+// Holds table of vire's pads smd pads
+// with pads Sl and Fl 
 int via_X[];
 int via_Y[];
 char via_Sl[];
@@ -206,8 +206,8 @@ string via_netname[];
 char via_pad_connectFlag[];   // Marks the pad as having connection to PAD, even if via a wire or direct,  via in pad.
 int via_counter;
 int via_index[];
-// Holds table of PAD's
-// for Pad's pad_Sl = 1  pad_Fl=16  ie all layers
+// Holds table of pads
+// for pads pad_Sl = 1  pad_Fl=16  ie all layers
 int pad_X[];
 int pad_Y[];
 char pad_Sl[];
@@ -272,11 +272,11 @@ string infoTargetDirectory  =  "<b>Set the target directory for the KiCad/Eagle 
 string infoConvertViaToPad  =  "<b>Eagle use's VIAs for connections to fill's and power plane's, this works well for Eagle<br>"+
     "<b>But will not work for KiCad, because KiCad does not retain Net list information for unconnected VIAs and tracks<br>"+
     "<b>It only retains net information when the via is connected to a PAD, using a track<br>"+
-    "<b>By converting the unconnected VIAs to Pad's KiCad will keep the net information and allow fill's and power plane's to work like<br>"+
+    "<b>By converting the unconnected VIAs to pads KiCad will keep the net information and allow fill's and power plane's to work like<br>"+
     "<b>they do on Eagle. But there  are some problems with this fix-<br><br>"+
     "1: Blind VIAs wont work, as Pads will go thou all layers,  while blind vie's only go thou the configured layers.<br>"+
-    "2: The fix change's the Eagle SCH/PCB file's by converting VIAs to Pads, the hack change's the SCH by adding 1 Pin Pad's<br>"+
-    "&nbsp;&nbsp;&nbsp;&nbsp;this is a very big hack, you will see x=0 y=0-number diffident net's and pad's in the Eagle SCH file<br>"+
+    "2: The fix change's the Eagle SCH/PCB file's by converting VIAs to Pads, the hack change's the SCH by adding 1 Pin pads<br>"+
+    "&nbsp;&nbsp;&nbsp;&nbsp;this is a very big hack, you will see x=0 y=0-number diffident net's and pads in the Eagle SCH file<br>"+
     "&nbsp;&nbsp;&nbsp;&nbsp;this mod-filed Eagle file's are saved in the $TARGETDIRECTOR/modified_eagle_files/";
 
 string infoDocFillOverPad  =  "<b>SMD Pads & Normal Pads can be covered with copper when Thermal connection is turned off<br>"+
@@ -290,11 +290,11 @@ string infoDocFillOverPad  =  "<b>SMD Pads & Normal Pads can be covered with cop
 
 
 string infoDocomentUnconnectVias  =  "<b>This Option add's a \">\" to the via or converted pad,<br>"+
-    "Making it easy to find the changed VIAs/pad's on the PCB<br>"+
+    "Making it easy to find the changed VIAs/pads on the PCB<br>"+
     "Note this will show up as layer eagleReportLayerTxt (tDocu) on Eagle's PCB, and Dwgs.User on KiCad pcbnew.<br>";
 
 string infoDocomentUnconnectWires  =  "<b>This Option add's a \">\" to the via or converted pad,<br>"+
-    "Making it easy to find the changed VIAs/pad's on the PCB<br>"+
+    "Making it easy to find the changed VIAs/pads on the PCB<br>"+
     "Note this will show up as layer eagleReportLayerTxt (tDocu) on Eagle's PCB, and Dwgs.User on KiCad pcbnew.<br>";
 
 
@@ -854,7 +854,7 @@ void menue(void)
                  "which are saved in the <i>TARGET-DIRECTORY</i>/modified_eagle_files/");
 
         /* "This is needed because KiCad does not support Net Names on unconected Via's/Tracks and blind Vias which have no Pad conecsion.!<br>"+ */
-        /* "while unconected VIAs can be automatic coveted to Pad's blind VIAs and unconnected tracks need manual conversion</i>)<br>"+ */
+        /* "while unconected VIAs can be automatic coveted to pads blind VIAs and unconnected tracks need manual conversion</i>)<br>"+ */
         /* "will lose net names, and will not connect to fill's or power plane's!<br>"+ */
         /* "This hack will help out by converting all those unconnected VIA'S to Pads<br>"+ */
         /* "<i>Click on Info for more, information and problem's which is could fix/make!</i><br>"+ */
@@ -936,7 +936,7 @@ void menue(void)
         {
           dlgStretch(10);
           dlgSpacing(space);
-          dlgLabel("Convert unconnected VIA's to PAD's");
+          dlgLabel("Convert unconnected VIA's to pads");
           dlgCheckBox("", enable_via_to_pad );
           dlgPushButton("Info") { if (dlgMessageBox( infoConvertViaToPad, "Ok") == 0); };
           dlgStretch(0);
@@ -1230,7 +1230,7 @@ int buildconnectintable()
 /*     { */
 
 /*       if( ( aIndex[ i ] ==  aindex[ j ] ) // pointing to our self's ? */
-/*         {  // Ok  step over then as pad's should not connect to pads.. I think !!! */
+/*         {  // Ok  step over then as pads should not connect to pads.. I think !!! */
 /*           j++; */
 /*           continue; */
 /*         } */
@@ -1682,7 +1682,7 @@ int main()
           {
             aX[ pad_counter ] = C.pad.x;
             aY[ pad_counter ] = C.pad.y;
-            aSl[ pad_counter ] = 1;    // thou hole pad's allways go's from top to Bottome
+            aSl[ pad_counter ] = 1;    // thou hole pads allways go's from top to Bottome
             aFl[ pad_counter ] = 16;
             aNet[ pad_counter ] = C.pad.signal;  // set the name up for now. 
             aType[ pad_counter ] = 0;   // PAD type
@@ -1743,7 +1743,7 @@ int main()
       {
         polygonCount++;
 
-        for( i = 0; i < pad_counter; i++ ) // check for pad's and fill netname match
+        for( i = 0; i < pad_counter; i++ ) // check for pads and fill netname match
         {
           if( aNet[i] == S.name ) // match the net ?
             if( (aSl[ i ] >= P.layer && (aFl[ i ] <= P.layer ))) // check to see if it's a pad or SMD pad,  only Mark SMD pad is on the same layer
@@ -1827,7 +1827,7 @@ int main()
         int t;
         if( overLappingPads )
         {
-          for( p = 0; p < pad_counter; p++)  // this looks strange but there may be a case when  the are two pad's at the same lowcation !
+          for( p = 0; p < pad_counter; p++)  // this looks strange but there may be a case when  the are two pads at the same lowcation !
           {
             t = findTableViaWire( i, via_counter, p,  1 ); // find first match and layers check
             if( t != 0 )
@@ -2358,7 +2358,7 @@ int main()
       }  // if( aStatus[i] == 0 )
 
     // Display marker for possable fill over pad.
-    for( i = 0; i < pad_counter; i++) // scan pad's for possable connections to fills
+    for( i = 0; i < pad_counter; i++) // scan pads for possable connections to fills
     {
       if((aFillPad[ i ]) == 1)// possable fill over pad ?
       {
@@ -2399,7 +2399,7 @@ int main()
       sprintf(c, "DISPLAY %s;\n", "NONE" );    
       pcb_cmd += c;
       sprintf(c, "DISPLAY %d %d %d %d %d %d %d %d %d %d %d %d;\n", ViaEagleReportLayerTxt, ViaEagleReportLayerDrawing, WireEagleReportLayerTxt, WireEagleReportLayerDrawing, PadEagleReportLayerText, PadEagleReportLayerDrawing,
-              BlindEagleReportLayerDrawing, BlindEagleReportLayerTxt, 17, 18, 23, 24 ); // dispaly VIAs pad's, and top/bottom orgiine
+              BlindEagleReportLayerDrawing, BlindEagleReportLayerTxt, 17, 18, 23, 24 ); // dispaly VIAs pads, and top/bottom orgiine
       pcb_cmd += c;
 
       for( i = 0; i < displayCt; i++ ) // Show layers with possable fill over pad
@@ -2420,7 +2420,7 @@ int main()
         np = findIntInArray( np, unc_wLayer[ i ] );
         if( np == 0 )
         {  // Not found so, we did not display before, so display it now!
-          sprintf(c, "DISPLAY %d;\n", unc_wLayer[ i ]); // dispaly VIAs pad's, and top/bottom orgiine
+          sprintf(c, "DISPLAY %d;\n", unc_wLayer[ i ]); // dispaly VIAs pads, and top/bottom orgiine
           pcb_cmd += c;
           sprintf(c, "SET FILL_LAYER %d 0;\n", unc_wLayer[ i ]);
           pcb_cmd += c;
@@ -2478,7 +2478,7 @@ int main()
     logfile += c;
     output(logfileName, "at") printf("%s", logfile);
 
-    // Write out the list of polygon's which have pad's VIAs for track's having the same net name.
+    // Write out the list of polygon's which have pads VIAs for track's having the same net name.
     if( polygons_linesCt )
     {
       polygons_message_FileName = filesetext( outputPath + filename(B.name), "_polygon_messagex.txt");

--- a/fix_via_hack.ulp
+++ b/fix_via_hack.ulp
@@ -31,7 +31,7 @@ string Version = "ULP Version 4.6.0";
  * 19.10.2015:  Add reporting of fill's over pads.  And clean up other reports.
  *              Thanks to: Lachlan  "lachlanusa (at) gmail.com" 
  *
- * 14.09.2015: Star adding reporting code for unnected tracks, and multi blind via's
+ * 14.09.2015: Star adding reporting code for unnected tracks, and multi blind VIAs
  *              Thanks to: Lachlan  "lachlanusa (at) gmail.com" 
  *
  * 09.09.2015: Add better plot of via pad change, Doc marker
@@ -118,7 +118,7 @@ string ckname[];
 
 string cmd;  // holds the script to renumbing in sch
 string lib_cmd; // hold's script for building lib pads
-string pcb_cmd; // Hold scrtip for removeing via's and adding pads in it's place.
+string pcb_cmd; // Hold scrtip for removeing VIAs and adding pads in it's place.
 string sch_cmd; // Hold script for sch pad's add.
 
 string c;
@@ -149,7 +149,7 @@ int aWireConnectionCt[]; // Holds the number of connections from wire to wire fo
 char aStatus[];	// the connection status,  0=NoConnected, 1=PadConnection.
 char aFillPad[]; // Marks the pad as having possable fill
 int wirenumber[];	// holds the wire number
-int aindex[];	// order storted index of pad/tracks/via's
+int aindex[];	// order storted index of pad/tracks/VIAs
 int index_size; // Holds the table size
 int table_error = 0; // Counter's any error's in the connection table,  should not heppen !
 
@@ -184,7 +184,7 @@ int docment_unnconeted_wires = 1;
 // but old/end is the marker..  IE index 10 is start, index of 11 is end of same track.
 // layer start finish are,  always the same vale,
 // so that same rutine can check for connection's for pad's
-// via's,  wire's  
+// VIAs,  wire's  
 int wire_X[];
 int wire_Y[];
 char wire_Sl[];  // layer start
@@ -269,19 +269,19 @@ string infoTargetDirectory  =  "<b>Set the target directory for the KiCad/Eagle 
                              "<b>Note this directory should be a clean directory<br>"+
                              "With out any other file's, as the contents-<br><center><font color=\"red\"><font color=\"red\">WILL BE OVER WRITTEN WITHOUT WARNING!</b></center>";
 
-string infoConvertViaToPad  =  "<b>Eagle use's via's for connections to fill's and power plane's, this works well for Eagle<br>"+
-    "<b>But will not work for KiCad, because KiCad does not retain Net list information for unconnected via's and tracks<br>"+
+string infoConvertViaToPad  =  "<b>Eagle use's VIAs for connections to fill's and power plane's, this works well for Eagle<br>"+
+    "<b>But will not work for KiCad, because KiCad does not retain Net list information for unconnected VIAs and tracks<br>"+
     "<b>It only retains net information when the via is connected to a PAD, using a track<br>"+
-    "<b>By converting the unconnected via's to Pad's KiCad will keep the net information and allow fill's and power plane's to work like<br>"+
+    "<b>By converting the unconnected VIAs to Pad's KiCad will keep the net information and allow fill's and power plane's to work like<br>"+
     "<b>they do on Eagle. But there  are some problems with this fix-<br><br>"+
-    "1: Blind via's wont work, as Pads will go thou all layers,  while blind vie's only go thou the configured layers.<br>"+
-    "2: The fix change's the Eagle SCH/PCB file's by converting via's to Pads, the hack change's the SCH by adding 1 Pin Pad's<br>"+
+    "1: Blind VIAs wont work, as Pads will go thou all layers,  while blind vie's only go thou the configured layers.<br>"+
+    "2: The fix change's the Eagle SCH/PCB file's by converting VIAs to Pads, the hack change's the SCH by adding 1 Pin Pad's<br>"+
     "&nbsp;&nbsp;&nbsp;&nbsp;this is a very big hack, you will see x=0 y=0-number diffident net's and pad's in the Eagle SCH file<br>"+
     "&nbsp;&nbsp;&nbsp;&nbsp;this mod-filed Eagle file's are saved in the $TARGETDIRECTOR/modified_eagle_files/";
 
 string infoDocFillOverPad  =  "<b>SMD Pads & Normal Pads can be covered with copper when Thermal connection is turned off<br>"+
     "<b>During importing of Eagle PCB, there is no control per PAD as to which  PAD is covered,  only global control per fill<br>"+
-    "<b>This leads to a problem's when you have via to Pad turned on, as if  thermal relief's is turned on for that fill, and via's<br>"+
+    "<b>This leads to a problem's when you have via to Pad turned on, as if  thermal relief's is turned on for that fill, and VIAs<br>"+
     "<b>to PAD been turned on, Thermal relief's are generated for each via/pad conversion which is not what you need.<br>"+
     "<b>In KiCad you have Global control and individual PAD control on thermal relive, so by turning Thermal relief off for the fill,<br>"+
     "<b>and turn each smd/pad Thermal relief on and needed.  Doing this manual<br>"+
@@ -290,11 +290,11 @@ string infoDocFillOverPad  =  "<b>SMD Pads & Normal Pads can be covered with cop
 
 
 string infoDocomentUnconnectVias  =  "<b>This Option add's a \">\" to the via or converted pad,<br>"+
-    "Making it easy to find the changed via's/pad's on the PCB<br>"+
+    "Making it easy to find the changed VIAs/pad's on the PCB<br>"+
     "Note this will show up as layer eagleReportLayerTxt (tDocu) on Eagle's PCB, and Dwgs.User on KiCad pcbnew.<br>";
 
 string infoDocomentUnconnectWires  =  "<b>This Option add's a \">\" to the via or converted pad,<br>"+
-    "Making it easy to find the changed via's/pad's on the PCB<br>"+
+    "Making it easy to find the changed VIAs/pad's on the PCB<br>"+
     "Note this will show up as layer eagleReportLayerTxt (tDocu) on Eagle's PCB, and Dwgs.User on KiCad pcbnew.<br>";
 
 
@@ -854,7 +854,7 @@ void menue(void)
                  "which are saved in the <i>TARGET-DIRECTORY</i>/modified_eagle_files/");
 
         /* "This is needed because KiCad does not support Net Names on unconected Via's/Tracks and blind Vias which have no Pad conecsion.!<br>"+ */
-        /* "while unconected via's can be automatic coveted to Pad's blind via's and unconnected tracks need manual conversion</i>)<br>"+ */
+        /* "while unconected VIAs can be automatic coveted to Pad's blind VIAs and unconnected tracks need manual conversion</i>)<br>"+ */
         /* "will lose net names, and will not connect to fill's or power plane's!<br>"+ */
         /* "This hack will help out by converting all those unconnected VIA'S to Pads<br>"+ */
         /* "<i>Click on Info for more, information and problem's which is could fix/make!</i><br>"+ */
@@ -1820,7 +1820,7 @@ int main()
       /* } */
 
       //      buildconnectintable();
-      // Mark via's with pad conntion.
+      // Mark VIAs with pad conntion.
       int p = 0; // Point to start PAD table
       for( i = wire_counter; i < via_counter; i++)
       {
@@ -1833,7 +1833,7 @@ int main()
             if( t != 0 )
             {
               t--;
-              aStatus[ t ] = 1; // mark via as connected to pad.. fix for smd/birred via's
+              aStatus[ t ] = 1; // mark via as connected to pad.. fix for smd/birred VIAs
               aNet[ p ] = S.name;  // Set net name of PAD
               aPadP[ i ] = t;	// Point via to pad
               via_to_padconnections++;
@@ -2227,7 +2227,7 @@ int main()
       logfile += c;
     }
     
-    for( i = 0; i < unnconnected_vias_Ct; i++) // scan table for unconnect via's
+    for( i = 0; i < unnconnected_vias_Ct; i++) // scan table for unconnect VIAs
     {
       // No, so docment and build scripts to add to sch and pcb and temporty lbr
 
@@ -2391,7 +2391,7 @@ int main()
 
         sprintf( c, "\nPADFILL\tPadCount=%d\t\tNet=%s\t\t\t\t(X=%f Y=%f)\tLayerStart=%d\tLayerEnd=%d", i+1, aNet[ i ], u2mic( aX[i]), u2mic( aY[i]), aSl[ i ],  aFl[ i ]);
         logfile += c;
-      }  // for( i = 0; i < unnconnected_vias_Ct; i++) // scan table for unconnect via's
+      }  // for( i = 0; i < unnconnected_vias_Ct; i++) // scan table for unconnect VIAs
     }
     
     if( display_error_layers && ( unnconnected_wires_Ct || unnconnected_vias_Ct ))
@@ -2399,7 +2399,7 @@ int main()
       sprintf(c, "DISPLAY %s;\n", "NONE" );    
       pcb_cmd += c;
       sprintf(c, "DISPLAY %d %d %d %d %d %d %d %d %d %d %d %d;\n", ViaEagleReportLayerTxt, ViaEagleReportLayerDrawing, WireEagleReportLayerTxt, WireEagleReportLayerDrawing, PadEagleReportLayerText, PadEagleReportLayerDrawing,
-              BlindEagleReportLayerDrawing, BlindEagleReportLayerTxt, 17, 18, 23, 24 ); // dispaly via's pad's, and top/bottom orgiine
+              BlindEagleReportLayerDrawing, BlindEagleReportLayerTxt, 17, 18, 23, 24 ); // dispaly VIAs pad's, and top/bottom orgiine
       pcb_cmd += c;
 
       for( i = 0; i < displayCt; i++ ) // Show layers with possable fill over pad
@@ -2420,7 +2420,7 @@ int main()
         np = findIntInArray( np, unc_wLayer[ i ] );
         if( np == 0 )
         {  // Not found so, we did not display before, so display it now!
-          sprintf(c, "DISPLAY %d;\n", unc_wLayer[ i ]); // dispaly via's pad's, and top/bottom orgiine
+          sprintf(c, "DISPLAY %d;\n", unc_wLayer[ i ]); // dispaly VIAs pad's, and top/bottom orgiine
           pcb_cmd += c;
           sprintf(c, "SET FILL_LAYER %d 0;\n", unc_wLayer[ i ]);
           pcb_cmd += c;
@@ -2435,7 +2435,7 @@ int main()
       viacount++;
     
 
-    //}  // for() // scan table for unconnect track/via's
+    //}  // for() // scan table for unconnect track/VIAs
     //  Do we have any polygons on this net ?
 
 
@@ -2478,7 +2478,7 @@ int main()
     logfile += c;
     output(logfileName, "at") printf("%s", logfile);
 
-    // Write out the list of polygon's which have pad's via's for track's having the same net name.
+    // Write out the list of polygon's which have pad's VIAs for track's having the same net name.
     if( polygons_linesCt )
     {
       polygons_message_FileName = filesetext( outputPath + filename(B.name), "_polygon_messagex.txt");
@@ -2521,7 +2521,7 @@ int main()
 
     /* if( blindviaCt ) */
     /* { */
-    /*     sprintf( blindviamessage, "%s","\t\t<font color=\"red\"><b>UNCONNECTED BLIND VIA(s)&nbsp;=%d\t<i>Remember to connect blind/birred via's to pad of the same netname with a track!<br><font color=\"black\">" ); */
+    /*     sprintf( blindviamessage, "%s","\t\t<font color=\"red\"><b>UNCONNECTED BLIND VIA(s)&nbsp;=%d\t<i>Remember to connect blind/birred VIAs to pad of the same netname with a track!<br><font color=\"black\">" ); */
     /* } */
     /* else */
     /*   sprintf( blindviamessage, "%s","\t\t<font color=\"green\"><b>UNCONNECTED BLIND VIA(s)\t\t=%d<br>" ); */
@@ -2543,12 +2543,12 @@ int main()
     
     if( unnconnected_wires_Ct || unnconnected_vias_Ct  )
     {
-      result = dlgDialog("Unnconnected via's and wire list")
+      result = dlgDialog("Unnconnected VIAs and wire list")
           {
             if( unnconnected_wires_Ct )
             {
               string c;
-              dlgLabel( "Consult log file for unnconted via's and tracks<br><b><i>" + logfileName +
+              dlgLabel( "Consult log file for unnconted VIAs and tracks<br><b><i>" + logfileName +
                         "</b></i><br> to help with fixing any warning's and errors");
               dlgLabel( x );
               sprintf(c, "<b><font color=\"red\">There are %d unnconnected Track(s)", unnconnected_wires_Ct );

--- a/fix_via_hack.ulp
+++ b/fix_via_hack.ulp
@@ -845,18 +845,18 @@ void menue(void)
   int saveAsDefaultULP_Path = 1;
   string tmpS10 = "";
   
-  result = dlgDialog("Via's to Pad, and Track Check:" + "  BUILD DATE:" + BUILD_DATE )
+  result = dlgDialog("VIAs to Pad, and Track Check:" + "  BUILD DATE:" + BUILD_DATE )
       {
-        dlgLabel("<b><font color=\"red\">This ULP will change unconnected VIA's to PADS<br>" + 
-                 "<font color=\"blue\">It will also Documents on user defined layer's unconnected VIA'S and Tracks<br>" +
+        dlgLabel("<b><font color=\"red\">This ULP will change unconnected VIAs to PADS<br>" + 
+                 "<font color=\"blue\">It will also Documents on user defined layer's unconnected VIAs and Tracks<br>" +
                  "<i>Click on <i>Info</> for importand Note's!</i><br>"+
                  "<b>NOTE:<i> This hack modifies both the Eagle SCH and PCB file,<br>"+
                  "which are saved in the <i>TARGET-DIRECTORY</i>/modified_eagle_files/");
 
-        /* "This is needed because KiCad does not support Net Names on unconected Via's/Tracks and blind Vias which have no Pad conecsion.!<br>"+ */
+        /* "This is needed because KiCad does not support Net Names on unconected VIAs/Tracks and blind Vias which have no Pad conecsion.!<br>"+ */
         /* "while unconected VIAs can be automatic coveted to pads blind VIAs and unconnected tracks need manual conversion</i>)<br>"+ */
         /* "will lose net names, and will not connect to fill's or power plane's!<br>"+ */
-        /* "This hack will help out by converting all those unconnected VIA'S to Pads<br>"+ */
+        /* "This hack will help out by converting all those unconnected VIAs to Pads<br>"+ */
         /* "<i>Click on Info for more, information and problem's which is could fix/make!</i><br>"+ */
         /* "<b>NOTE:<i> This hack modifies both the eagle sch and PCB file,  which are saved in the TARGET-DIRECTORY/modified_eagle_files/</i>"); */
 
@@ -936,7 +936,7 @@ void menue(void)
         {
           dlgStretch(10);
           dlgSpacing(space);
-          dlgLabel("Convert unconnected VIA's to pads");
+          dlgLabel("Convert unconnected VIAs to pads");
           dlgCheckBox("", enable_via_to_pad );
           dlgPushButton("Info") { if (dlgMessageBox( infoConvertViaToPad, "Ok") == 0); };
           dlgStretch(0);
@@ -976,7 +976,7 @@ void menue(void)
         {
           dlgStretch(10);
           dlgSpacing(space);
-          dlgLabel("Documents unconnected VIA's");
+          dlgLabel("Documents unconnected VIAs");
           dlgCheckBox("", docment_via_to_pad );
           dlgLabel("Text Layer");
           dlgIntEdit(ViaEagleReportLayerTxt, 100, 255);
@@ -992,7 +992,7 @@ void menue(void)
         {
           dlgStretch(10);
           dlgSpacing(space);
-          dlgLabel("Documents unconnected Blind VIA's");
+          dlgLabel("Documents unconnected Blind VIAs");
           dlgCheckBox("", docment_blind_via_to_pad );
           dlgLabel("Text Layer");
           dlgIntEdit( BlindEagleReportLayerTxt, 100, 255);

--- a/fix_via_hack.ulp
+++ b/fix_via_hack.ulp
@@ -28,7 +28,7 @@ string Version = "ULP Version 4.6.0";
  * 11.02.2016:  Change ! to ~ for onver bard on KiCad
  *              Thanks to: Lachlan  "lachlanusa (at) gmail.com" 
  *
- * 19.10.2015:  Add reporting of fill's over pads.  And clean up other reports.
+ * 19.10.2015:  Add reporting of fills over pads.  And clean up other reports.
  *              Thanks to: Lachlan  "lachlanusa (at) gmail.com" 
  *
  * 14.09.2015: Star adding reporting code for unnected tracks, and multi blind VIAs
@@ -269,10 +269,10 @@ string infoTargetDirectory  =  "<b>Set the target directory for the KiCad/Eagle 
                              "<b>Note this directory should be a clean directory<br>"+
                              "With out any other file's, as the contents-<br><center><font color=\"red\"><font color=\"red\">WILL BE OVER WRITTEN WITHOUT WARNING!</b></center>";
 
-string infoConvertViaToPad  =  "<b>Eagle use's VIAs for connections to fill's and power plane's, this works well for Eagle<br>"+
+string infoConvertViaToPad  =  "<b>Eagle use's VIAs for connections to fills and power plane's, this works well for Eagle<br>"+
     "<b>But will not work for KiCad, because KiCad does not retain Net list information for unconnected VIAs and tracks<br>"+
     "<b>It only retains net information when the via is connected to a PAD, using a track<br>"+
-    "<b>By converting the unconnected VIAs to pads KiCad will keep the net information and allow fill's and power plane's to work like<br>"+
+    "<b>By converting the unconnected VIAs to pads KiCad will keep the net information and allow fills and power plane's to work like<br>"+
     "<b>they do on Eagle. But there  are some problems with this fix-<br><br>"+
     "1: Blind VIAs wont work, as Pads will go thou all layers,  while blind vie's only go thou the configured layers.<br>"+
     "2: The fix change's the Eagle SCH/PCB file's by converting VIAs to Pads, the hack change's the SCH by adding 1 Pin pads<br>"+
@@ -855,7 +855,7 @@ void menue(void)
 
         /* "This is needed because KiCad does not support Net Names on unconected VIAs/Tracks and blind Vias which have no Pad conecsion.!<br>"+ */
         /* "while unconected VIAs can be automatic coveted to pads blind VIAs and unconnected tracks need manual conversion</i>)<br>"+ */
-        /* "will lose net names, and will not connect to fill's or power plane's!<br>"+ */
+        /* "will lose net names, and will not connect to fills or power plane's!<br>"+ */
         /* "This hack will help out by converting all those unconnected VIAs to Pads<br>"+ */
         /* "<i>Click on Info for more, information and problem's which is could fix/make!</i><br>"+ */
         /* "<b>NOTE:<i> This hack modifies both the eagle sch and PCB file,  which are saved in the TARGET-DIRECTORY/modified_eagle_files/</i>"); */

--- a/fix_via_hack.ulp
+++ b/fix_via_hack.ulp
@@ -269,7 +269,7 @@ string infoTargetDirectory  =  "<b>Set the target directory for the KiCad/Eagle 
                              "<b>Note this directory should be a clean directory<br>"+
                              "With out any other file's, as the contents-<br><center><font color=\"red\"><font color=\"red\">WILL BE OVER WRITTEN WITHOUT WARNING!</b></center>";
 
-string infoConvertViaToPad  =  "<b>Eagle use's VIAs for connections to fills and power planes, this works well for Eagle<br>"+
+string infoConvertViaToPad  =  "<b>Eagle uses VIAs for connections to fills and power planes, this works well for Eagle<br>"+
     "<b>But will not work for KiCad, because KiCad does not retain Net list information for unconnected VIAs and tracks<br>"+
     "<b>It only retains net information when the via is connected to a PAD, using a track<br>"+
     "<b>By converting the unconnected VIAs to pads KiCad will keep the net information and allow fills and power planes to work like<br>"+

--- a/renumber-sheet.ulp
+++ b/renumber-sheet.ulp
@@ -529,7 +529,7 @@ void menue(void)
           dlgCheckBox("Save as default", saveAsDefaultULP_Path );
           dlgPushButton("Edit") {
             string xs;int it;
-            xs = dlgDirectory("Select directory containing conversion ULP's", "C:\\");
+            xs = dlgDirectory("Select directory containing conversion ULPs", "C:\\");
             if( strlen(xs) )
               tmpS10 = myULP_HOME = xs + '/';
           }


### PR DESCRIPTION
Further to the README changes I previously made in #19, I noticed quite a few errors in the dialog boxes that were distracting me from paying attention to the contents.

I've done a number of global substitutions here, based on the assumption that it should only have touched strings and not code. A further assumption is that all apostrophes are wrong. I'm happy to be proven wrong on either count. I've not thoroughly tested and checked the resultant changes, but I'm pretty happy with them and I believe they are sufficiently seperate to appropriate blame to any particular change and fix accordingly.